### PR TITLE
Closes #3: Remove clj-time dep

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,7 +6,7 @@
   :dependencies [
                  [org.clojure/clojure "1.6.0"]
                  ;; [org.clojure/clojure "1.7.0-master-SNAPSHOT"]
-                 [clj-time "0.9.0"]
+                 ;; [clj-time "0.9.0"]
                  ;; [leiningen "2.5.0"]
                  ;; [lein-ubersource "0.1.1"]
                  ;; [org.bitbucket.mstrobel/procyon-compilertools "0.5.27"]

--- a/src/debugger/config.clj
+++ b/src/debugger/config.clj
@@ -1,5 +1,5 @@
 (ns debugger.config
-  (:require [clj-time.core :as t]))
+  (:require [debugger.time :as t]))
 
 (declare ^:dynamic *locals*)
 (def ^:dynamic *break-outside-repl* false)

--- a/src/debugger/core.clj
+++ b/src/debugger/core.clj
@@ -1,5 +1,5 @@
 (ns debugger.core
-  (:require [clj-time.core :as t]
+  (:require [debugger.time :as t]
             [debugger.config :refer :all]
             [debugger.formatter :refer [deanonimize-name
                                         demunge

--- a/src/debugger/repl.clj
+++ b/src/debugger/repl.clj
@@ -1,6 +1,6 @@
 (ns debugger.repl
   (:require [clojure.pprint :refer [pprint]]
-            [clj-time.core :as t]
+            [debugger.time :as t]
             [clojure.string :as s]
             [debugger.config :refer :all]
             [debugger.formatter :refer [non-std-trace-element?]]

--- a/src/debugger/time.clj
+++ b/src/debugger/time.clj
@@ -1,0 +1,18 @@
+(ns debugger.time
+  (:import java.util.Date
+           java.util.concurrent.TimeUnit))
+
+(defn now []
+  (Date.))
+
+(defn seconds [^Integer n]
+  (.toMillis (TimeUnit/SECONDS) n))
+
+(defn in-seconds [n]
+  (.toSeconds (TimeUnit/MILLISECONDS) n))
+
+(defn interval [^Date a ^Date b]
+  (- (.getTime b) (.getTime a)))
+
+(defn minus [^Date t period]
+  (Date. (- (.getTime t) period)))

--- a/test/debugger/time_test.clj
+++ b/test/debugger/time_test.clj
@@ -1,0 +1,26 @@
+(ns debugger.time-test
+  (:import java.util.Date)
+  (:require [debugger.time :refer :all]
+            [clojure.test :refer :all]))
+
+(deftest now-test []
+  (is (= (.getTime (Date.)) (.getTime (now)))))
+
+
+(deftest minus-test []
+  (is (= (-> (Date.).getTime (- 2000) (Date.) .getTime)
+         (-> (now) (minus (seconds 2)) .getTime))))
+
+(deftest interval-test []
+  (is (= 4 (-> (now)
+               (minus (seconds 4))
+               (interval (now))
+               (in-seconds)))))
+
+(deftest compatibility-test []
+  (are [last-quit-seconds-ago skip-repl-if-last-quit-ago check]
+    (is (= check (->> (now) (interval (minus (now) (seconds last-quit-seconds-ago))) in-seconds (< skip-repl-if-last-quit-ago))))
+    4 2 true
+    3 2 true
+    2 2 false
+    1 2 false))


### PR DESCRIPTION
I would really like to see progress on https://github.com/clojure-emacs/cider-nrepl/pull/170 so I've created a drop-in replacement of the parts of clj-time used by clj-debugger. Solution based on Java's Date.
