### PR TITLE
Replace some? with not-nil to drop 1.6 dependency. Close #4

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,7 +4,7 @@
   :license {:name "Eclipse Public License"
             :url "http://www.eclipse.org/legal/epl-v10.html"}
   :dependencies [
-                 [org.clojure/clojure "1.6.0"]
+                 [org.clojure/clojure "1.5.0"]
                  ;; [org.clojure/clojure "1.7.0-master-SNAPSHOT"]
                  [clj-time "0.9.0"]
                  ;; [leiningen "2.5.0"]

--- a/src/debugger/commands.clj
+++ b/src/debugger/commands.clj
@@ -49,7 +49,8 @@
       :else
         (do
           (println)
-          (println (clojure.string/join "\n" (filter some? lines)) "\n")))))
+          (println (clojure.string/join "\n" (filter #(not (nil? %)) lines))
+                   "\n")))))
 
 (defn print-trace
   ([trace] (print-trace (constantly true) trace))

--- a/src/debugger/formatter.clj
+++ b/src/debugger/formatter.clj
@@ -47,7 +47,7 @@
      (fn [width] (str "%-" width "s"))]))
 
 (defn format-line-with-line-numbers [short? break-line line-number line]
-  {:pre (some? break-line)}
+  {:pre (not (nil? break-line))}
   (cond
     (= break-line line-number) (str "=> " line-number ": " line)
     (and short? (<= line-number (- break-line *code-context-lines*))) nil
@@ -75,7 +75,7 @@
 
 
 (defn fn-try [f & args]
-  (if (some? (first args))
+  (if (not (nil? (first args)))
     (apply f args)
     nil))
 


### PR DESCRIPTION
Removed all uses of `some?`. AFAIC this was the only thing that depends on 1.6. 
How can I check properly?
