### PR TITLE
Make library lintable using eastwood

### DIFF
--- a/src/debugger/commands.clj
+++ b/src/debugger/commands.clj
@@ -1,5 +1,4 @@
 (ns debugger.commands
-  (:use debugger.config)
   (:require [debugger.config :refer :all]
             [debugger.formatter :refer [safe-find-var
                                         no-sources-found

--- a/src/debugger/formatter.clj
+++ b/src/debugger/formatter.clj
@@ -54,13 +54,15 @@
     (and short? (>= line-number (+ break-line *code-context-lines*))) nil
     :else (str "   " line-number ": " line)))
 
-(defn deanonimize-name [^String s]
+(defn deanonimize-name
   "Inner qualified names `debugger.core-test/err/fn--4248` -> no source found"
+  [^String s]
   (clojure.string/join "/" (take 2 (clojure.string/split s #"/"))))
 
 
-(defn safe-find-var [sym]
+(defn safe-find-var
   "No raise of not found ns of symbol"
+  [sym]
   (and (-> sym namespace symbol find-ns)
        (-> sym find-var)))
 

--- a/src/debugger/main.clj
+++ b/src/debugger/main.clj
@@ -1,5 +1,5 @@
 (ns debugger.main
-  (:use [debugger core])
+  (:require [debugger.core :refer :all])
   (:gen-class))
 
 ;; `lein run -m debugger.main 1 2` shouldn't stop in debugger

--- a/test/debugger/core_test.clj
+++ b/test/debugger/core_test.clj
@@ -3,10 +3,6 @@
             [clojure.walk :refer [postwalk-demo]]
             [debugger.core :refer :all]))
 
-(deftest a-test
-  (testing "FIXME, I fail."
-    (is (= 1 1))))
-
 (def wow 1)
 
 (defn foo [& args]

--- a/test/debugger/time_test.clj
+++ b/test/debugger/time_test.clj
@@ -3,21 +3,21 @@
   (:require [debugger.time :refer :all]
             [clojure.test :refer :all]))
 
-(deftest now-test []
+(deftest now-test
   (is (= (.getTime (Date.)) (.getTime (now)))))
 
 
-(deftest minus-test []
+(deftest minus-test
   (is (= (-> (Date.).getTime (- 2000) (Date.) .getTime)
          (-> (now) (minus (seconds 2)) .getTime))))
 
-(deftest interval-test []
+(deftest interval-test
   (is (= 4 (-> (now)
                (minus (seconds 4))
                (interval (now))
                (in-seconds)))))
 
-(deftest compatibility-test []
+(deftest compatibility-test
   (are [last-quit-seconds-ago skip-repl-if-last-quit-ago check]
     (is (= check (->> (now) (interval (minus (now) (seconds last-quit-seconds-ago))) in-seconds (< skip-repl-if-last-quit-ago))))
     4 2 true


### PR DESCRIPTION
Hi, first of all - thanks for open sourcing clj-debugger!

This patch fixes some warnings raised by the [eastwood](https://github.com/jonase/eastwood) lint tool, and makes a slight modification to allow eastwood to lint the project (and any project dependent on it) without erroring.

The root of the problem is that `tools.analyzer`, which eastwood uses to analyze Clojure code, provides an `&env` of a different shape to that of `clojure.lang.Compiler` (see [TANAL-13](http://dev.clojure.org/jira/browse/TANAL-13)) - so we now filter out any key-value pairs that do not have a value of type `clojure.lang.Compiler$LocalBinding` (i.e. for normal usage we filter out nothing; this only has an affect when `tools.analyzer` in play).
